### PR TITLE
Pass decode errors to the client as well

### DIFF
--- a/src/main/java/de/tbressler/waterrower/io/codec/RxtxMessageParser.java
+++ b/src/main/java/de/tbressler/waterrower/io/codec/RxtxMessageParser.java
@@ -2,6 +2,7 @@ package de.tbressler.waterrower.io.codec;
 
 import de.tbressler.waterrower.io.msg.AbstractMessage;
 import de.tbressler.waterrower.io.msg.IMessageInterpreter;
+import de.tbressler.waterrower.io.msg.in.DecodeErrorMessage;
 import de.tbressler.waterrower.io.msg.interpreter.*;
 import de.tbressler.waterrower.log.Log;
 
@@ -92,9 +93,7 @@ public class RxtxMessageParser {
                 return decodedMsg;
         }
 
-        Log.warn(SERIAL, "Message couldn't be decoded! Unknown message '"+ msg +"'.");
-
-        return null;
+        return new DecodeErrorMessage(msg);
     }
 
 

--- a/src/main/java/de/tbressler/waterrower/io/msg/in/DecodeErrorMessage.java
+++ b/src/main/java/de/tbressler/waterrower/io/msg/in/DecodeErrorMessage.java
@@ -1,0 +1,27 @@
+package de.tbressler.waterrower.io.msg.in;
+
+import de.tbressler.waterrower.io.msg.AbstractMessage;
+
+import static com.google.common.base.MoreObjects.toStringHelper;
+
+/**
+ * Decode error message.
+ */
+public class DecodeErrorMessage extends AbstractMessage {
+
+    private String message;
+
+    public DecodeErrorMessage(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return this.message;
+    }
+
+    @Override
+    public String toString() {
+        return toStringHelper(this).toString();
+    }
+
+}


### PR DESCRIPTION
These decode errors are currently silently ignored and not passed to client. This will allow clients to handle these errors as well.